### PR TITLE
Avoid warning when callback is defined several times

### DIFF
--- a/lib/knigge/behaviour.ex
+++ b/lib/knigge/behaviour.ex
@@ -31,6 +31,7 @@ defmodule Knigge.Behaviour do
     module
     |> Module.get_attribute(:callback)
     |> Enum.map(&Knigge.AST.function_spec_from_callback/1)
+    |> Enum.uniq()
   end
 
   def optional_callbacks(module) do

--- a/test/knigge/behaviour_test.exs
+++ b/test/knigge/behaviour_test.exs
@@ -17,5 +17,18 @@ defmodule Knigge.BehaviourTest do
         assert Knigge.Behaviour.callbacks(__MODULE__) == [my_great_function: 1]
       end
     end
+
+    test "with duplicated callbacks" do
+      defmodule DuplicatedBehaviour do
+        @callback my_function(String.t()) :: no_return
+        @callback my_function(atom()) :: no_return
+        @optional_callbacks my_function: 1
+        assert Knigge.Behaviour.callbacks(__MODULE__) == [my_function: 1]
+        assert Knigge.Behaviour.optional_callbacks(__MODULE__) == [my_function: 1]
+      end
+
+      assert Knigge.Behaviour.callbacks(DuplicatedBehaviour) == [my_function: 1]
+      assert Knigge.Behaviour.optional_callbacks(DuplicatedBehaviour) == [my_function: 1]
+    end
   end
 end


### PR DESCRIPTION
Solves #5 