### PR TITLE
ci: Add action to publish main docs on pushes

### DIFF
--- a/.github/workflows/dev_release.yml
+++ b/.github/workflows/dev_release.yml
@@ -1,0 +1,61 @@
+name: Dev Release
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  MIX_ENV: dev
+  REQUIRE_VERSION_FILE: true
+  CACHE_PREFIX_DEPS: v1-deps
+  CACHE_PREFIX_BUILD: v1-_build
+
+jobs:
+  publish_to_hex:
+    name: Publish to Hex.pm
+    runs-on: ubuntu-latest
+    container: hexpm/elixir:1.11.2-erlang-22.3.4.3-alpine-3.11.6
+    env:
+      VERSION_ALPINE: 3.11.6
+      VERSION_ELIXIR: 1.11.2
+      VERSION_OTP: 22.3.4.3
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: rickstaa/action-get-semver@v1
+        id: update_semver
+        with:
+          bump_level: "minor"
+
+      - name: Update semver and write the release version file
+        run: |
+          echo "Create version file for ${{ steps.update_semver.outputs.next-version }}-dev"
+          echo "${{ steps.update_semver.outputs.next-version }}-dev > version"
+
+      - name: Cache - deps/
+        uses: actions/cache@v1
+        with:
+          path: deps/
+          key: ${{ env.CACHE_PREFIX_DEPS }}-env:${{ env.MIX_ENV }}-alpine:${{ env.VERSION_ALPINE }}-elixir:${{ env.VERSION_ELIXIR }}-otp:${{ env.VERSION_OTP }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ env.CACHE_PREFIX_DEPS }}-env:${{ env.MIX_ENV }}-alpine:${{ env.VERSION_ALPINE }}-elixir:${{ env.VERSION_ELIXIR }}-otp:${{ env.VERSION_OTP }}-
+
+      - name: Install Dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get --only "$MIX_ENV"
+
+      - name: Cache - _build/
+        uses: actions/cache@v1
+        with:
+          path: _build/
+          key: ${{ env.CACHE_PREFIX_BUILD }}-env:${{ env.MIX_ENV }}-alpine:${{ env.VERSION_ALPINE }}-elixir:${{ env.VERSION_ELIXIR }}-otp:${{ env.VERSION_OTP }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ env.CACHE_PREFIX_BUILD }}-env:${{ env.MIX_ENV }}-alpine:${{ env.VERSION_ALPINE }}-elixir:${{ env.VERSION_ELIXIR }}-otp:${{ env.VERSION_OTP }}-
+
+      - run: mix compile --warnings-as-errors
+
+      - name: Publish to Hex.pm
+        run: mix hex.publish --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
Fixes #23

-----------------
This PR adds an action that when some code i pushed into main (this include merged pull requests) it will do the same checks that the `release` action does (this is actually the release action copied, but the version file is generated in a different way) and if everything goes right, it will publish a release to `hexdocs` using the format `<next-version>-dev` (where <next-version> is the current version with a minor dump).

PS: `mix format --check-formatted` is failing, but this PR doesnt change any file rather then adding the action file, should i run `mix format` ?

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [X] Feature branch is up-to-date with `main` (if not - merge `main` into your branch).
* [ ] Added tests.
* [X] Ran `mix check.all`, it verifies the formatting and runs `credo` and `dialyzer`
* [X] Ran `mix test`
* [ ] Added an entry to the [Changelog](https://github.com/sascha-wolf/knigge/blob/main/CHANGELOG.md) if the new code introduces user-observable changes. See the [changelog entry format](https://github.com/sascha-wolf/knigge/blob/main/CONTRIBUTING.md#changelog-entry-format).
